### PR TITLE
Fix User Import Error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -47,11 +47,18 @@ const importUserChunk = async (chunk: UserImportRecord[]) => {
 
 const importUsersFromFile = async (filePath: string) => {
   const fileContent = fs.readFileSync(filePath, 'utf-8');
-  const users: UserImportRecord[] = JSON.parse(fileContent).map((user: any) => ({
-    ...user,
-    passwordHash: Buffer.from(user.passwordHash, 'base64'),
-    passwordSalt: Buffer.from(user.passwordSalt, 'base64'),
-  }));
+  const users: UserImportRecord[] = JSON.parse(fileContent).map(
+    (user: any) => {
+      const userData: UserImportRecord = { ...user };
+      if (user.passwordHash) {
+        userData.passwordHash = Buffer.from(user.passwordHash, "base64");
+      }
+      if (user.passwordSalt) {
+        userData.passwordSalt = Buffer.from(user.passwordSalt, "base64");
+      }
+      return userData;
+    }
+  );
 
   const userChunks = chunkArray(users, 1000);
   for (const chunk of userChunks) {


### PR DESCRIPTION
This pull request addresses an issue encountered during user import, where a `TypeError [ERR_INVALID_ARG_TYPE]` was thrown. The error message indicated that the first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array-like Object, but `undefined` was received.

### Error Details:
```
Error importing users: TypeError [ERR_INVALID_ARG_TYPE]: The first argument must be of type string or an instance of Buffer, ArrayBuffer, or Array-like Object. Received undefined
    at new NodeError (node:internal/errors:405:5)
    at Function.from (node:buffer:325:9)
    at /home/vszabo/Git/auth-scheduled-backup-import/src/index.ts:54:28
    at Array.map (<anonymous>)
    at /home/vszabo/Git/auth-scheduled-backup-import/src/index.ts:50:61
    at Generator.next (<anonymous>)
    at /home/vszabo/Git/auth-scheduled-backup-import/src/index.ts:31:71
    at new Promise (<anonymous>)
    at __awaiter (/home/vszabo/Git/auth-scheduled-backup-import/src/index.ts:27:12)
    at importUsersFromFile (/home/vszabo/Git/auth-scheduled-backup-import/src/index.ts:48:56) {
  code: 'ERR_INVALID_ARG_TYPE'
}
```

### Changes Made:
- Fixed the argument type issue in the `importUsersFromFile` function to ensure the correct type is passed.
- Added validation to handle cases where the argument might be `undefined`.

### Testing:
- Tested the user import functionality to ensure the error is resolved.
- Verified that users are imported successfully without any issues.

### Related Issue:
- #1 

Please review and merge this fix to resolve the user import error.